### PR TITLE
Deleted 'space' symbol between 'data:' and '<type>' to avoid W3C markup ...

### DIFF
--- a/src/jnmorse/DataUri/Image.php
+++ b/src/jnmorse/DataUri/Image.php
@@ -19,7 +19,7 @@ class Image
 
     public function __toString ()
     {
-        $uri  = "data: {$this->type};base64,{$this->file}";
+        $uri  = "data:{$this->type};base64,{$this->file}";
 
         return $uri;
     }


### PR DESCRIPTION
Deleted 'space' symbol between 'data:' and '<type>' to avoid W3C markup validation errors